### PR TITLE
feat: 新增 天氣與股票API測試與 Mock文件與筆記

### DIFF
--- a/docs/mock_note.md
+++ b/docs/mock_note.md
@@ -1,0 +1,116 @@
+# Mock 筆記：使用 unittest.mock 模擬外部依賴
+ 
+本筆記記錄了在 Python 測試中使用 `@patch` 與 `MagicMock` 來模擬外部資源（如 API 請求）的方法與原理。
+ 
+---
+ 
+## 1. 為什麼要使用 Mock？
+ 
+在單元測試時，我們希望：
+- 測試執行快速
+- 不依賴外部系統（如 API、資料庫、檔案系統）
+- 可重現、不會因外部狀態改變導致失敗
+ 
+因此，我們會使用 mock 技術「攔截」這些外部依賴，並回傳模擬的結果。
+ 
+---
+ 
+## 2. 範例場景說明
+ 
+```python
+# src/stock.py
+import requests
+ 
+def get_stock_price(stock_id: str) -> dict:
+    url = f"https://api.stock.example/{stock_id}"
+    response = requests.get(url)
+    return response.json()
+```
+
+---
+ 
+## 3. 使用 @patch 模擬 requests.get
+ 
+# tests/test_stock.py
+```
+import unittest
+from unittest.mock import patch
+from src.stock import get_stock_price
+ 
+class TestStockAPI(unittest.TestCase):
+ 
+    @patch("src.stock.requests.get")
+    def test_get_stock_price_mocked(self, mock_get):
+        mock_get.return_value.json.return_value = {
+            "stock_id": "2330",
+            "price": 650,
+            "currency": "TWD"
+        }
+ 
+        result = get_stock_price("2330")
+        self.assertEqual(result["stock_id"], "2330")
+        self.assertEqual(result["price"], 650)
+        self.assertEqual(result["currency"], "TWD")
+```
+---
+ 
+## 4. patch 的行為解釋
+```
+@patch("src.stock.requests.get")
+```
+這表示：
+
+> 將「src.stock 模組中使用的 requests.get」替換成一個 MagicMock 物件。
+ 
+- mock_get()：模擬呼叫 requests.get()
+ 
+- mock_get.return_value：模擬回傳的 Response 物件
+ 
+- mock_get.return_value.json.return_value：模擬 .json() 回傳資料
+ 
+ 
+ 
+---
+ 
+## 5. MagicMock 是什麼？
+ 
+MagicMock 是 unittest.mock 提供的萬用物件，可自由設定：
+ 
+- 回傳值 (return_value)
+ 
+- 呼叫時報錯 (side_effect)
+ 
+- 方法 (mock.method())
+ 
+ 
+範例：
+```
+mock_get.return_value.status_code = 200
+mock_get.side_effect = TimeoutError("API timeout!")
+```
+ 
+---
+ 
+## 6. 對照圖表：真實邏輯 vs Mock 模擬邏輯
+ 
+| 真實邏輯                          | Mock 模擬邏輯                                |
+|-----------------------------------|---------------------------------------------|
+| `requests.get()`                  | `mock_get()`                                |
+| `response = requests.get(...)`    | `mock_get.return_value`                     |
+| `response.json()`                 | `mock_get.return_value.json()`              |
+| `return response.json()`          | `mock_get.return_value.json.return_value`   |
+
+
+---
+ 
+## 7. 小結語
+ 
+> 被 patch 的物件不會發出真實請求，它們會被 MagicMock 替換掉，
+測試者可以精準控制每個步驟的結果，使測試能穩定、安全、快速進行。
+ 
+ 
+ 
+Mock 是現代自動化測試中不可或缺的技能，透過這份筆記快速回顧，你將更自在地掌握它！
+ 
+---
+ 

--- a/src/stock.py
+++ b/src/stock.py
@@ -1,0 +1,6 @@
+import requests
+
+def get_stock_price(stock_id: str) -> dict:
+    url = f'https://api.stock.example/{stock_id}'
+    response = requests.get(url)
+    return response.json()

--- a/src/weather.py
+++ b/src/weather.py
@@ -1,0 +1,6 @@
+import requests
+
+def get_weather(city:str) -> dict:
+    url = f'https://api.weather.example/{city}'
+    response = requests.get(url)
+    return response.json()

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -1,0 +1,18 @@
+import unittest
+from unittest.mock import patch
+from src.stock import get_stock_price
+
+class TestStockAPI(unittest.TestCase):
+    @patch("src.stock.requests.get")
+    def test_get_stock_price_mocked(self,mock_get):
+        # 模擬API回傳資料
+        mock_get.return_value.json.return_value = {
+            "stock_id": "2330",
+            "price": 650,
+            "currency": "TWD"
+        }
+        result = get_stock_price("2330")
+
+        self.assertEqual(result["stock_id"],"2330")
+        self.assertEqual(result["price"],650)
+        self.assertEqual(result["currency"],"TWD")

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest.mock import patch
+from src.weather import get_weather
+
+class TestWeatherAPI(unittest.TestCase):
+    @patch("src.weather.requests.get")
+    def test_get_weather_mocked(self,mock_get):
+        #模擬response
+        mock_get.return_value.json.return_value = {
+            "city" : "Taipei",
+            "temp" : 25,
+            "status" : "sunny"
+        }
+
+
+        result = get_weather("Taipei")
+
+        self.assertEqual(result['city'],"Taipei")
+        self.assertEqual(result['temp'],25)
+        self.assertEqual(result['status'],"sunny")


### PR DESCRIPTION
### 主要變更內容
 
本次 PR 包含以下兩部分內容：
 
1. **API 測試模組：**
   - 新增 `src/stock.py`：模擬股票查詢 API 函式 `get_stock_price()`
   - 新增 `tests/[test_stock.py](http://test_stock.py/)`：使用 `unittest.mock.patch` 模擬 `requests.get` 請求
   - 避免實際 API 發送，改為以假資料進行測試，提高測試穩定性
 
2. **筆記文件：**
   - 新增 `docs/mock_note.md`
   - 詳細紀錄 Mock 的使用方式、語法說明、MagicMock 結構與流程對照表
   - 作為日後 Mock 技術複習與面試作品集的佐證內容
 
---
 
### 測試覆蓋率說明
- `test_stock.py` 為 100% 覆蓋率
- 模擬情境中涵蓋正常流程、資料欄位驗證

---
 
### 測試覆蓋率報告
 
以下為目前整體專案覆蓋率統計（由 coverage 產生）：
 
- 總體覆蓋率：**97%**
- 核心模組（weather, stock）皆為 100%
- 測試項目分類完整、命名一致
 
![image](https://github.com/user-attachments/assets/8bc1d0e1-b493-435f-8cf0-2dc51e423eec)
 
---

### 後續展望（備註）
 
- 可逐步擴充更多外部依賴模擬（如 time、random、file I/O）
- Mock 筆記將與 CI/CD 筆記一同構成 DevOps 初階測試設計的基礎文檔