### PR TITLE
test: 重構api/divide.py的邏輯問題；修正raiseError在不同測試中的狀態；新增test_api_divide_route

### DIFF
--- a/api/divide.py
+++ b/api/divide.py
@@ -4,17 +4,17 @@ from fastapi.responses import JSONResponse
 app = FastAPI()
 
 #FastAPI轉換，這裡可以把型別辨識移除，因為FastAPI已經會自行辨識
-@app.get("/api/divide")
-async def divide_endpoint(a: float , b: float):
-    try:
-        if b == 0:
-            raise ValueError("除數不能為0!!")
-        return {
-            "a":a,
-            "b":b,
-            "result":a/b
-        }
-    except ValueError as e:
-        return JSONResponse(status_code=400,content={"error":str(e)})    
+
+async def divide_core(a: float , b: float):
+    if not isinstance(a,(int,float)) or not isinstance(b,(int,float)):
+        raise ValueError("除數與被除數必須為實數!!")
+    if b == 0:
+        print("DEBUG觸發數字錯誤")
+        raise ValueError("除數不能為0")
+    return {
+        "a":a,
+        "b":b,
+        "result":a/b
+    }    
 
     

--- a/main.py
+++ b/main.py
@@ -1,19 +1,16 @@
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
+from api.divide import divide_core
 
 app = FastAPI()
 
 #FastAPI轉換，這裡可以把型別辨識移除，因為FastAPI已經會自行辨識
 @app.get("/api/divide")
 async def divide_endpoint(a: float , b: float):
+    print("開始執行main")
     try:
-        if b == 0:
-            raise ValueError("除數不能為0!!")
-        return {
-            "a":a,
-            "b":b,
-            "result":a/b
-        }
+        result = await divide_core(a , b)
+        return result
     except ValueError as e:
         return JSONResponse(status_code=400,content={"error":str(e)})    
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+httpx
+coverage

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -10,4 +10,4 @@ class TestAdd(unittest.TestCase):
             add(1,'E')
             self.fail("觸發錯誤ValueError,但是沒有發生")
         except ValueError as e:
-            self.assertIn("數字",str(e))
+            self.assertIn("數值",str(e))

--- a/tests/test_api_divide.py
+++ b/tests/test_api_divide.py
@@ -1,19 +1,22 @@
 import unittest
-from api.divide import apiDivide
+import asyncio
+import inspect
+from api.divide import divide_core
+print("[DEBUG] divide core from :" ,inspect.getfile(divide_core))
 
 class TestApiDivide(unittest.TestCase):
     def test_api_divide_valid(self):
-        res = apiDivide(10,2)
-        print(res)
+        res = asyncio.run(divide_core(10,2))
+        self.assertEqual(res["result"],5)
     #
     def test_api_divide_by_zero(self):
+        tt = ''
         with self.assertRaises(ValueError) as context:
-
-            apiDivide(10,0)
-        self.assertIn("除數必須為",str(context.exception))
+            asyncio.run(divide_core(10,0))
+        self.assertIn("不能為0",str(context.exception)) #
     #
     def test_api_divide_by_word(self):
+        aa = ''
         with self.assertRaises(ValueError) as context:
-
-            apiDivide(10,'E')
-        self.assertIn("除數必須為",str(context.exception))
+            asyncio.run(divide_core(10,'E'))
+        self.assertIn("須為實數",str(context.exception)) #

--- a/tests/test_api_divide_route.py
+++ b/tests/test_api_divide_route.py
@@ -1,0 +1,23 @@
+import unittest
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+class TestClientRoute(unittest.TestCase):
+    def test_valid_division(self):
+        response = client.get("/api/divide?a=10&b=2")
+
+        self.assertEqual(response.status_code , 200)
+        self.assertEqual(response.json(), {"a": 10.0 , "b": 2.0 , "result": 5.0 })
+
+    def test_divide_by_zero(self):
+        response = client.get("/api/divide?a=10&b=0")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.json())
+ 
+    def test_invalid_input(self):
+        response = client.get("/api/divide?a=abc&b=3")
+        self.assertEqual(response.status_code, 422)
+
+

--- a/tests/test_divide.py
+++ b/tests/test_divide.py
@@ -13,7 +13,7 @@ class TestDivide(unittest.TestCase):
             divide('100',5)
             self.fail("觸發ValueError,但是沒有發生")
         except ValueError as e:
-            self.assertIn("數字",str(e))
+            self.assertIn("數值",str(e))
     def test_math_divide_small_number(self): 
         result = divide(1,1e-10)
         self.assertAlmostEqual(result , 1e10)

--- a/tests/test_subtract.py
+++ b/tests/test_subtract.py
@@ -9,4 +9,4 @@ class TestSubtract(unittest.TestCase):
             subtract('E',2)
             self.fail("觸發錯誤ValueError,但是沒有發生")
         except ValueError as e:
-            self.assertIn("數字",str(e))
+            self.assertIn("數值",str(e))


### PR DESCRIPTION
### 說明
本 PR 為 `divide_core` 測試修正的最終整理：
 
- 修正 `api/divide.py` 中錯誤拋出邏輯，移除 `JSONResponse` 包裝
- 修正部分`raiseError`錯誤邏輯
- 測試使用 `assertRaises` 與 `asyncio.run` 驗證錯誤行為
- 與 FastAPI route 結構分離
- 為日後筆記補充與 tag v1.2 做鋪墊